### PR TITLE
Potential fix for code scanning alert no. 2: Email content injection

### DIFF
--- a/handlers/contact.go
+++ b/handlers/contact.go
@@ -7,9 +7,9 @@ import (
 	"github.com/dhawalhost/leapmailr/config"
 	"github.com/dhawalhost/leapmailr/models"
 	"github.com/dhawalhost/leapmailr/service"
+	"github.com/dhawalhost/leapmailr/utils"
 
 	"github.com/gin-gonic/gin"
-	"regexp"
 )
 
 // HandleContactForm handles the contact form submission
@@ -30,7 +30,8 @@ func HandleContactForm(c *gin.Context) {
 	// Sender and recipient details
 	sender := models.Sender{Name: conf.CompanyName, Email: conf.DefaultSenderMail}
 	// Validate email format
-	if !isValidEmail(form.Email) {
+
+	if !utils.IsValidEmail(form.Email) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid email address"})
 		return
 	}
@@ -59,4 +60,3 @@ func HandleContactForm(c *gin.Context) {
 		"message": form.Message,
 	})
 }
-

--- a/handlers/contact.go
+++ b/handlers/contact.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dhawalhost/leapmailr/service"
 
 	"github.com/gin-gonic/gin"
+	"regexp"
 )
 
 // HandleContactForm handles the contact form submission
@@ -28,6 +29,11 @@ func HandleContactForm(c *gin.Context) {
 
 	// Sender and recipient details
 	sender := models.Sender{Name: conf.CompanyName, Email: conf.DefaultSenderMail}
+	// Validate email format
+	if !isValidEmail(form.Email) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid email address"})
+		return
+	}
 	recipient := models.Recipient{Name: form.Name, Email: form.Email}
 
 	// Sending to Person who contacted
@@ -53,3 +59,4 @@ func HandleContactForm(c *gin.Context) {
 		"message": form.Message,
 	})
 }
+

--- a/utils/validator.go
+++ b/utils/validator.go
@@ -1,0 +1,8 @@
+package utils
+
+import "net/mail"
+
+func IsValidEmail(email string) bool {
+	_, err := mail.ParseAddress(email)
+	return err == nil
+}


### PR DESCRIPTION
Potential fix for [https://github.com/dhawalhost/leapmailr/security/code-scanning/2](https://github.com/dhawalhost/leapmailr/security/code-scanning/2)

To fix the problem, we need to ensure that any user-controlled input used in constructing the email headers or body is properly sanitized. Specifically, we should validate the `recipient.Email` field to ensure it is a well-formed email address before using it in the email headers. Additionally, we should sanitize any other user-controlled input that might be used in the email content.

The best way to fix this issue without changing existing functionality is to add email validation for the `recipient.Email` field. We can use a regular expression to validate the email format. This validation should be added in the `HandleContactForm` function in `handlers/contact.go`.
